### PR TITLE
get_items returns set or list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 dist/
 build/
 *egg-info
+
+\.idea/

--- a/wmi_query/__init__.py
+++ b/wmi_query/__init__.py
@@ -1,4 +1,0 @@
-"""Import for tests."""
-from .wmi_conn import * # NOQA
-from .wmi_query import * # NOQA
-from .wmi_parse import * #NOQA

--- a/wmi_query/wmi_conn.py
+++ b/wmi_query/wmi_conn.py
@@ -38,8 +38,8 @@ def wmi_conn(address, username, password, domain, namespace, query):
             _list_wmi_data.append(_iwb_class_object.Next(0xffffffff, 1)[0])
     except DCERPCException:
         pass
-
-    _iwb_nt_login.RemRelease()
-    _dcom.disconnect()
+    finally:
+        _iwb_nt_login.RemRelease()
+        _dcom.disconnect()
 
     return _list_wmi_data

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -3,7 +3,7 @@
 """The class wmi_query returns a defaultdict with objects of specific class."""
 
 
-import wmi_conn
+from . import wmi_conn
 from collections import defaultdict
 from datetime import datetime, timedelta
 

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -3,7 +3,7 @@
 """The class wmi_query returns a defaultdict with objects of specific class."""
 
 
-import wmi_conn
+import wmi_query.wmi_conn as wmi_conn
 from collections import defaultdict
 from datetime import datetime, timedelta
 

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -59,7 +59,11 @@ class wmi_query(object):
 
         Eg: object.get_items('OS_Name')
         """
-        return set([self.data_dict[self.dict_name][x][item_name]
+        try:
+            return set([self.data_dict[self.dict_name][x][item_name]
+                    for x, y in enumerate(self.data_dict[self.dict_name])])
+        except TypeError:
+            return ([self.data_dict[self.dict_name][x][item_name]
                     for x, y in enumerate(self.data_dict[self.dict_name])])
 
     def get_item_keys(self):

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -3,7 +3,7 @@
 """The class wmi_query returns a defaultdict with objects of specific class."""
 
 
-import wmi_query.wmi_conn as wmi_conn
+import wmi_conn
 from collections import defaultdict
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
Hi kanazux,
when I was starting to query our windows Servers, i found your module very usefull. But I encountered an issue when I was querying Win32_NetworkAdapterConfiguration. So I made this change: https://github.com/kanazux/wmi-query/commit/628e976b519c3607b455ac29e6d5b1a2f3aa8bc0

Some day I had some issues loading wmi-query at all (using python 3.x) (Yeah, I know, not an good explanation. I can't remember from top of my Head what was going on). That's the reason for the other changes.
