### PR TITLE
Fix hang after rpc s access denied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 dist/
 build/
 *egg-info
+
+\.idea/

--- a/wmi_query/__init__.py
+++ b/wmi_query/__init__.py
@@ -1,4 +1,0 @@
-"""Import for tests."""
-from .wmi_conn import * # NOQA
-from .wmi_query import * # NOQA
-from .wmi_parse import * #NOQA

--- a/wmi_query/wmi_conn.py
+++ b/wmi_query/wmi_conn.py
@@ -38,8 +38,8 @@ def wmi_conn(address, username, password, domain, namespace, query):
             _list_wmi_data.append(_iwb_class_object.Next(0xffffffff, 1)[0])
     except DCERPCException:
         pass
-
-    _iwb_nt_login.RemRelease()
-    _dcom.disconnect()
+    finally:
+        _iwb_nt_login.RemRelease()
+        _dcom.disconnect()
 
     return _list_wmi_data

--- a/wmi_query/wmi_conn.py
+++ b/wmi_query/wmi_conn.py
@@ -25,8 +25,15 @@ def wmi_conn(address, username, password, domain, namespace, query):
     _dcom = DCOMConnection(address, username, password, domain,
                            oxidResolver=True, doKerberos=False,
                            kdcHost=address)
-    _interface = _dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login,
-                                          wmi.IID_IWbemLevel1Login)
+    try:
+        _interface = _dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login,
+                                              wmi.IID_IWbemLevel1Login)
+    except DCERPCException as e:
+        try:
+            _dcom.disconnect()
+        except KeyError:
+            pass
+        raise e
     _web_level1_login = wmi.IWbemLevel1Login(_interface)
     _iwb_nt_login = _web_level1_login.NTLMLogin(namespace, NULL, NULL)
     _web_level1_login.RemRelease()

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -3,7 +3,7 @@
 """The class wmi_query returns a defaultdict with objects of specific class."""
 
 
-import wmi_conn
+from . import wmi_conn
 from collections import defaultdict
 from datetime import datetime, timedelta
 

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -3,7 +3,7 @@
 """The class wmi_query returns a defaultdict with objects of specific class."""
 
 
-import wmi_conn
+import wmi_query.wmi_conn as wmi_conn
 from collections import defaultdict
 from datetime import datetime, timedelta
 

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -59,7 +59,11 @@ class wmi_query(object):
 
         Eg: object.get_items('OS_Name')
         """
-        return set([self.data_dict[self.dict_name][x][item_name]
+        try:
+            return set([self.data_dict[self.dict_name][x][item_name]
+                    for x, y in enumerate(self.data_dict[self.dict_name])])
+        except TypeError:
+            return ([self.data_dict[self.dict_name][x][item_name]
                     for x, y in enumerate(self.data_dict[self.dict_name])])
 
     def get_item_keys(self):

--- a/wmi_query/wmi_query.py
+++ b/wmi_query/wmi_query.py
@@ -3,7 +3,7 @@
 """The class wmi_query returns a defaultdict with objects of specific class."""
 
 
-import wmi_query.wmi_conn as wmi_conn
+import wmi_conn
 from collections import defaultdict
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
see: #5 
When creating _interface (perparing WMI LogiN) fails by an DCERPCException this will be catched. Then try to close the connection. If this fails because for this particular host hasn't been established a connection before, will the corresponding exception also be caught. At least the catched DCERPCException will be raised, so the caller can handle it.